### PR TITLE
removed rending 'redis request duration' to statsd

### DIFF
--- a/lib/rack/session/redis/stats_collector.rb
+++ b/lib/rack/session/redis/stats_collector.rb
@@ -4,8 +4,7 @@ require 'statsd/client'
 module Rack
   module Session
     module Redis
-      # Using 'dawanda-statsd-client' in order to collect statistics about avg. request duration
-      # and the number of timeouts when invoking a given block of code, see StatsCollector#with_stats
+      # Using 'dawanda-statsd-client' in order to collect number of timeouts when invoking a given block of code, see StatsCollector#with_stats
       module StatsCollector
         REQUEST_DURATION = 'sessions.request_duration'
         TIMEOUT_COUNTER = 'sessions.timeout'
@@ -13,11 +12,7 @@ module Rack
         # Sends duration of a given block invocation to statsd. Increment 'session.timeout' counter on exception.
         def with_stats
           return unless block_given?
-          start = Time.now
-          result = yield
-          duration = (Time.now - start) * 1000 # duration in ms
-          statsd_client.timing(REQUEST_DURATION, duration.round)
-          result
+          yield
         rescue ::Redis::TimeoutError => e
           # collects stats
           statsd_client.increment(TIMEOUT_COUNTER)

--- a/spec/stats_collector_spec.rb
+++ b/spec/stats_collector_spec.rb
@@ -23,21 +23,21 @@ describe Rack::Session::Redis::StatsCollector do
   it 'should increase the timeout counter on TimeoutError' do
     expect(client).to receive(:statsd_client).and_return(statsd_client)
     expect(statsd_client).to receive(:increment).with(Rack::Session::Redis::StatsCollector::TIMEOUT_COUNTER)
+    begin
+      client.with_stats do
+        raise Redis::TimeoutError
+      end
+    rescue
+    end
+  end
 
+  it 'should re-raise Redis::TimeoutError if timeout occurred during invocation of the block' do
+    expect(client).to receive(:statsd_client).and_return(statsd_client)
+    expect(statsd_client).to receive(:increment)
     expect {
       client.with_stats do
         raise Redis::TimeoutError
       end
     }.to raise_error Redis::TimeoutError
-  end
-
-  it 'should measure the time of invocation' do
-    expect(client).to receive(:statsd_client).and_return(statsd_client)
-    duration = 1000
-    expect(statsd_client).to receive(:timing).with(Rack::Session::Redis::StatsCollector::REQUEST_DURATION, be_between(1000, 2000))
-
-    client.with_stats do
-      sleep(1)
-    end
   end
 end


### PR DESCRIPTION
removed rending 'redis request duration' to statsd
