### PR TITLE
take session ID from Authorization header

### DIFF
--- a/lib/rack/session/redis/session_service.rb
+++ b/lib/rack/session/redis/session_service.rb
@@ -48,6 +48,16 @@ module Rack
         end
 
         #override
+        def extract_session_id(env)
+          sid = super
+          # Take sid from Authorization header
+          if sid.nil? && !@cookie_only && auth = env['HTTP_AUTHORIZATION']
+            sid = (auth.match(/#{@key} (\w+)/) || [])[1]
+          end
+          sid
+        end
+
+        #override
         def get_session(env, sid)
           with_stats do
             unless sid && session = @store.load(sid)

--- a/spec/session_service_spec.rb
+++ b/spec/session_service_spec.rb
@@ -1,5 +1,6 @@
 require 'rack/session/redis/session_service'
 require 'rack/session/redis/redis_session_store'
+require 'rack'
 
 describe Rack::Session::Redis::SessionService do
 
@@ -33,6 +34,18 @@ describe Rack::Session::Redis::SessionService do
     allow(session_store).to receive(:load).and_return(fake_session)
     allow(session_store).to receive(:exists?).and_return(false)
     allow(session_store).to receive(:invalidate).and_return(fake_session)
+  end
+
+  it 'should take the session from the Authorization header if not found in the cookie' do
+    session_service = Rack::Session::Redis::SessionService.new(nil, { key: 'foobar', cookie_only: false })
+    expect(
+      session_service.extract_session_id({
+        'HTTP_AUTHORIZATION' => 'foobar 8s7dg98dsa7ft087',
+        'QUERY_STRING'       => '',
+        'REQUEST_METHOD'     => 'GET',
+        'rack.input'         => []
+      })
+    ).to eq('8s7dg98dsa7ft087')
   end
 
   it 'should check if the generated sid is not present in the underlying store' do


### PR DESCRIPTION
If option cookie_only is set to false and session ID cannot be found in the
cookies or in the params, then also try to get it from the Authorization header.

This makes it more convenient for mobile apps to pass the session.

The format of the header is:

```
Authorization: session_key session_value
```

So, if session key is _dawanda_session and value is abc1234, then the header
should be set to:

```
Authorization: _dawanda_session abc1234
```

@lucatironi please review
