### PR TITLE
assert session match and allow injecting Redis client

### DIFF
--- a/lib/rack/session/redis/redis_session_store.rb
+++ b/lib/rack/session/redis/redis_session_store.rb
@@ -11,8 +11,8 @@ module Rack
         def initialize(options)
           raise ArgumentError, 'No :default_expiration value provided' unless options[:default_expiration]
           @default_expiration = options[:default_expiration]
-          @key_prefix = options[:key_prefix] || ''
-          @redis = ::Redis.new(options)
+          @key_prefix         = options[:key_prefix] || ''
+          @redis              = options[:redis] || ::Redis.new(options)
         end
 
         # Determine if a key exists.

--- a/lib/rack/session/redis/session_service.rb
+++ b/lib/rack/session/redis/session_service.rb
@@ -60,7 +60,9 @@ module Rack
         #override
         def get_session(env, sid)
           with_stats do
-            unless sid && session = @store.load(sid)
+            if sid && session = @store.load(sid)
+              assert_session_match!(sid, session)
+            else
               sid, session = generate_sid, {}
               unless @store.create(sid, session)
                 raise "Session collision on '#{sid.inspect}'"
@@ -87,7 +89,16 @@ module Rack
             generate_sid unless options[:drop]
           end
         end
+
+        private def assert_session_match!(session_id, session)
+          return if session.empty?
+          if session[:_dawanda_sid] != session_id
+            raise SessionMismatchError.new("#{session_id.inspect} does not match #{session[:_dawanda_sid].inspect}")
+          end
+        end
       end
+
+      class SessionMismatchError < StandardError; end
     end
   end
 end

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -13,16 +13,15 @@ describe Rack::Session::Redis::RedisSessionStore do
     {:sample_key => 'sample-value', :user => {:id => 'john-doe'}}
   }
 
-  let(:store) {
-    Rack::Session::Redis::RedisSessionStore.new(:default_expiration => 3600, :key_prefix => PREFIX)
-  }
-
   let(:redis) {
     double(:redis_instance)
   }
 
+  let(:store) {
+    Rack::Session::Redis::RedisSessionStore.new(:default_expiration => 3600, :key_prefix => PREFIX, :redis => redis)
+  }
+
   before do
-    allow(Redis).to receive(:new).and_return(redis)
     allow(redis).to receive(:exists).and_return(false)
     allow(redis).to receive(:get).and_return(Marshal.dump(value))
     allow(redis).to receive(:setnx).and_return(true)
@@ -74,7 +73,7 @@ describe Rack::Session::Redis::RedisSessionStore do
   end
 
   it 'should set default expiration if :expire_after option not specified' do
-    store = Rack::Session::Redis::RedisSessionStore.new(:default_expiration => 1234, :key_prefix => PREFIX)
+    store = Rack::Session::Redis::RedisSessionStore.new(:default_expiration => 1234, :key_prefix => PREFIX, redis: redis)
     expect(redis).to receive(:setex).with(anything, 1234, anything)
     store.store(key, value)
   end


### PR DESCRIPTION
The assertion makes sure we cannot return a wrong session in case of memory
corruption

It is now possible to pass a redis client, instead of instantiating one for
every initialization
