### PR TITLE
Solve deprecation in rack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
-source 'http://dawanda_dist:fnord_dist@dist.dawanda.in'
+source 'https://dawanda_dist:fnord_dist@gems.dawanda.in'
 # Specify your gem's dependencies in rack-session-redis.gemspec
 gemspec

--- a/lib/rack/session/redis/session_service.rb
+++ b/lib/rack/session/redis/session_service.rb
@@ -21,8 +21,8 @@ module Rack
       # statsd_host: 'statsd:8125',
       # key_prefix: 'my:session:'
       #
-      # You can use all options supported by Rack::Session::Abstract::ID.
-      class SessionService < ::Rack::Session::Abstract::ID
+      # You can use all options supported by Rack::Session::Abstract::Persited.
+      class SessionService < ::Rack::Session::Abstract::Persisted
         include StatsCollector
 
         # default session expiration time
@@ -58,7 +58,7 @@ module Rack
         end
 
         #override
-        def get_session(env, sid)
+        def find_session(env, sid)
           with_stats do
             if sid && sid.size > 20 && session = @store.load(sid)
               assert_session_match!(sid, session)
@@ -73,7 +73,7 @@ module Rack
         end
 
         #override
-        def set_session(env, sid, session, options)
+        def write_session(env, sid, session, options)
           with_stats do
             # sid key name which stores the session id inside a session object; backward compatibility with identity
             session[:_dawanda_sid] = sid unless session.empty?
@@ -83,7 +83,7 @@ module Rack
         end
 
         #override
-        def destroy_session(env, sid, options)
+        def delete_session(env, sid, options)
           with_stats do
             @store.invalidate(sid)
             generate_sid unless options[:drop]

--- a/lib/rack/session/redis/session_service.rb
+++ b/lib/rack/session/redis/session_service.rb
@@ -48,10 +48,10 @@ module Rack
         end
 
         #override
-        def extract_session_id(env)
+        def extract_session_id(request)
           sid = super
           # Take sid from Authorization header
-          if sid.nil? && !@cookie_only && auth = env['HTTP_AUTHORIZATION']
+          if sid.nil? && !@cookie_only && auth = request.env['HTTP_AUTHORIZATION']
             sid = (auth.match(/#{@key} (\w+)/) || [])[1]
           end
           sid

--- a/lib/rack/session/redis/version.rb
+++ b/lib/rack/session/redis/version.rb
@@ -1,7 +1,7 @@
 module Rack
   module Session
     module Redis
-      VERSION = "0.0.20"
+      VERSION = '1.0.0'
     end
   end
 end

--- a/rack-session-redis.gemspec
+++ b/rack-session-redis.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
   spec.add_development_dependency 'loveos-common'
-  spec.add_dependency 'rack'
+  spec.add_dependency 'rack', '~> 2.0'
   spec.add_dependency 'redis'
   spec.add_dependency 'dawanda-statsd-client'
 end

--- a/spec/session_service_spec.rb
+++ b/spec/session_service_spec.rb
@@ -40,12 +40,12 @@ describe Rack::Session::Redis::SessionService do
   it 'should take the session from the Authorization header if not found in the cookie' do
     session_service = Rack::Session::Redis::SessionService.new(nil, { key: 'foobar', cookie_only: false })
     expect(
-      session_service.extract_session_id({
+      session_service.extract_session_id(Rack::Request.new({
         'HTTP_AUTHORIZATION' => 'foobar 8s7dg98dsa7ft087',
         'QUERY_STRING'       => '',
         'REQUEST_METHOD'     => 'GET',
         'rack.input'         => []
-      })
+      }))
     ).to eq('8s7dg98dsa7ft087')
   end
 


### PR DESCRIPTION
Rack 2 has rename multiple methods that this gem is overriding, so we need to match them again