### PR TITLE
Add user id index & revert to stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
-source 'https://dawanda_dist:fnord_dist@gems.dawanda.in'
+source 'http://dawanda_dist:fnord_dist@dist.dawanda.in'
 # Specify your gem's dependencies in rack-session-redis.gemspec
 gemspec

--- a/lib/rack/session/redis/redis_session_store.rb
+++ b/lib/rack/session/redis/redis_session_store.rb
@@ -41,6 +41,7 @@ module Rack
         # @return [String] provided value
         def store(key, value, options = {})
           expiration = options[:expire_after] || @default_expiration
+          user_id = value['_dawanda_user_id']
           value = Marshal.dump(value)
           redis_key = prefix(key)
           if expiration > 0
@@ -48,6 +49,7 @@ module Rack
           else
             @redis.set(redis_key, value)
           end
+          store_user_session(user_id, redis_key) unless user_id.nil?
           value
         end
 
@@ -82,6 +84,10 @@ module Rack
           else
             key
           end
+        end
+
+        def store_user_session(user_id, session_key)
+          @redis.sadd("dawanda:user_sessions:#{user_id}", session_key)
         end
       end
     end

--- a/lib/rack/session/redis/session_service.rb
+++ b/lib/rack/session/redis/session_service.rb
@@ -48,10 +48,10 @@ module Rack
         end
 
         #override
-        def extract_session_id(request)
+        def extract_session_id(env)
           sid = super
           # Take sid from Authorization header
-          if sid.nil? && !@cookie_only && auth = request.env['HTTP_AUTHORIZATION']
+          if sid.nil? && !@cookie_only && auth = env['HTTP_AUTHORIZATION']
             sid = (auth.match(/#{@key} (\w+)/) || [])[1]
           end
           sid

--- a/lib/rack/session/redis/session_service.rb
+++ b/lib/rack/session/redis/session_service.rb
@@ -21,8 +21,8 @@ module Rack
       # statsd_host: 'statsd:8125',
       # key_prefix: 'my:session:'
       #
-      # You can use all options supported by Rack::Session::Abstract::Persited.
-      class SessionService < ::Rack::Session::Abstract::Persisted
+      # You can use all options supported by Rack::Session::Abstract::ID.
+      class SessionService < ::Rack::Session::Abstract::ID
         include StatsCollector
 
         # default session expiration time
@@ -58,7 +58,7 @@ module Rack
         end
 
         #override
-        def find_session(env, sid)
+        def get_session(env, sid)
           with_stats do
             if sid && sid.size > 20 && session = @store.load(sid)
               assert_session_match!(sid, session)
@@ -73,7 +73,7 @@ module Rack
         end
 
         #override
-        def write_session(env, sid, session, options)
+        def set_session(env, sid, session, options)
           with_stats do
             # sid key name which stores the session id inside a session object; backward compatibility with identity
             session[:_dawanda_sid] = sid unless session.empty?
@@ -83,7 +83,7 @@ module Rack
         end
 
         #override
-        def delete_session(env, sid, options)
+        def destroy_session(env, sid, options)
           with_stats do
             @store.invalidate(sid)
             generate_sid unless options[:drop]

--- a/lib/rack/session/redis/version.rb
+++ b/lib/rack/session/redis/version.rb
@@ -1,7 +1,7 @@
 module Rack
   module Session
     module Redis
-      VERSION = "0.0.20"
+      VERSION = "0.1.0"
     end
   end
 end

--- a/lib/rack/session/redis/version.rb
+++ b/lib/rack/session/redis/version.rb
@@ -1,7 +1,7 @@
 module Rack
   module Session
     module Redis
-      VERSION = '1.0.0'
+      VERSION = "0.0.20"
     end
   end
 end

--- a/rack-session-redis.gemspec
+++ b/rack-session-redis.gemspec
@@ -20,10 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
   spec.add_development_dependency 'loveos-common'
-  spec.add_dependency 'rack', '~> 2.0'
+  spec.add_dependency 'rack'
   spec.add_dependency 'redis'
   spec.add_dependency 'dawanda-statsd-client'
 end

--- a/spec/session_service_spec.rb
+++ b/spec/session_service_spec.rb
@@ -56,14 +56,14 @@ describe Rack::Session::Redis::SessionService do
 
   it 'should create new empty session and new session id if session_id does not exist' do
     allow(session_store).to receive(:load).and_return(nil)
-    id, session = session_service.find_session(nil, sid)
+    id, session = session_service.get_session(nil, sid)
     expect(id).not_to eq(sid)
     expect(session).to eq({})
   end
 
   it 'should return existing session for a given id' do
     expect(session_store).to receive(:load).with(sid).and_return(fake_session)
-    id, session = session_service.find_session(nil, sid)
+    id, session = session_service.get_session(nil, sid)
     expect(id).to eq(sid)
     expect(session).to eq(fake_session)
   end
@@ -81,33 +81,34 @@ describe Rack::Session::Redis::SessionService do
   it 'should throw exception on session collision' do
     allow(session_store).to receive(:create).and_return(false)
     allow(session_store).to receive(:load).and_return(nil)
-    expect { session_service.find_session(nil, sid) }.to raise_error RuntimeError
+    expect { session_service.get_session(nil, sid) }.to raise_error RuntimeError
   end
 
-  it 'should delete session and return new session id' do
+  it 'should destroy session and return new session id' do
     expect(session_store).to receive(:invalidate).with(sid)
-    new_sid = session_service.delete_session(nil, sid, {})
+    new_sid = session_service.destroy_session(nil, sid, {})
     expect(new_sid).to_not eq(sid)
   end
 
   it 'raises SessionMismatchError if _dawanda_sid inside the session does not match session id' do
     allow(session_store).to receive(:load).with(sid).and_return(foo: 'bar', _dawanda_sid: 'wrong-session-id')
     expect {
-      session_service.find_session(nil, sid)
+      session_service.get_session(nil, sid)
     }.to raise_error(Rack::Session::Redis::SessionMismatchError)
   end
 
   it 'does not raise SessionMismatchError if session is empty' do
     allow(session_store).to receive(:load).with(sid).and_return({})
     expect {
-      session_service.find_session(nil, sid)
+      session_service.get_session(nil, sid)
     }.not_to raise_error
   end
 
   it 'regenerate a new session ID if the given one is too short' do
     allow(session_store).to receive(:load).with(sid).and_return({})
     allow(session_store).to receive(:create).and_return(true)
-    sid, session = session_service.find_session(nil, 'abcd')
+    sid, session = session_service.get_session(nil, 'abcd')
     expect(sid).not_to eq('abcd')
   end
+
 end

--- a/spec/session_service_spec.rb
+++ b/spec/session_service_spec.rb
@@ -40,12 +40,12 @@ describe Rack::Session::Redis::SessionService do
   it 'should take the session from the Authorization header if not found in the cookie' do
     session_service = Rack::Session::Redis::SessionService.new(nil, { key: 'foobar', cookie_only: false })
     expect(
-      session_service.extract_session_id(Rack::Request.new({
+      session_service.extract_session_id({
         'HTTP_AUTHORIZATION' => 'foobar 8s7dg98dsa7ft087',
         'QUERY_STRING'       => '',
         'REQUEST_METHOD'     => 'GET',
         'rack.input'         => []
-      }))
+      })
     ).to eq('8s7dg98dsa7ft087')
   end
 


### PR DESCRIPTION
We need this secondary index in order to bulk invalidate user sessions when a user resets or changes their password (for security reasons).

This PR also reverts the last 3 commits, which made this gem incompatible with all the active repos that use it :upside_down_face: 