### PR TITLE
Fix ruby 2.4 compatibility

### DIFF
--- a/lib/rack/session/redis/session_service.rb
+++ b/lib/rack/session/redis/session_service.rb
@@ -41,7 +41,7 @@ module Rack
         end
 
         def generate_sid
-          loop do
+          while true do
             sid = super
             break sid unless @store.exists?(sid)
           end

--- a/lib/rack/session/redis/version.rb
+++ b/lib/rack/session/redis/version.rb
@@ -1,7 +1,7 @@
 module Rack
   module Session
     module Redis
-      VERSION = "0.1.0"
+      VERSION = "0.1.1"
     end
   end
 end


### PR DESCRIPTION
For reasons I do not understand, `super` fails inside this `loop` block, but works completely fine if using `while true` in ruby 2.4.  This fixes the error so that loveos-backend can update to ruby 2.4.